### PR TITLE
FK-34 User 생성 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/mysql/

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,13 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.8'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: mysql:8.3.0
     container_name: mysql_user
     environment:
-      MYSQL_ROOT_PASSWORD: mysql
-      MYSQL_DATABASE: user_service
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT}:3306"
     volumes:
       - ./mysql:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "4"
+services:
+  mysql:
+    image: mysql:8.3.0
+    container_name: mysql_user
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_DATABASE: user_service
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql:/var/lib/mysql
+

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/UserServiceApplication.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/UserServiceApplication.java
@@ -2,7 +2,11 @@ package com.capston_design.fkiller.itoms.user_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class UserServiceApplication {
 

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/ApiResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload;
+
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/ErrorStatus.java
@@ -1,7 +1,7 @@
 package com.capston_design.fkiller.itoms.user_service.apiPayload.code.status;
 
-import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.BaseErrorCode;
-import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ErrorReasonDTO;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.BaseErrorCode;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.ErrorReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -43,7 +43,6 @@ public enum ErrorStatus implements BaseErrorCode {
                 .code(code)
                 .isSuccess(false)
                 .httpStatus(httpStatus)
-                .build()
-                ;
+                .build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,49 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code.status;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.BaseErrorCode;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    // 멤버 관려 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+
+    // Ror test
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,43 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.code.status;
+
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.BaseCode;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    // 멤버 관련 응답
+
+    // ~~~ 관련 응답
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,119 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.exception;
+
+import com.capston_design.fkiller.itoms.user_service.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.ErrorReasonDTO;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/apiPayload/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.capston_design.fkiller.itoms.user_service.apiPayload.exception;
+
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.BaseErrorCode;
+import com.capston_design.fkiller.itoms.user_service.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/config/SwaggerConfig.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.capston_design.fkiller.itoms.user_service.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Service Desk API Document",
+                version = "1.0",
+                description = "Itoms Service Desk 기능을 수행하는 API document 페이지 입니다"
+        )
+)
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI serviceDeskOpenAPI() {
+        return new OpenAPI();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/controller/UserController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.capston_design.fkiller.itoms.user_service.controller;
+
+import com.capston_design.fkiller.itoms.user_service.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.user_service.converter.UserConverter;
+import com.capston_design.fkiller.itoms.user_service.dto.UserRequest;
+import com.capston_design.fkiller.itoms.user_service.dto.UserResponse;
+import com.capston_design.fkiller.itoms.user_service.model.User;
+import com.capston_design.fkiller.itoms.user_service.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<UserResponse.UserCreateResponseDTO>> createUser(
+            @RequestBody UserRequest userRequest) {
+
+        User user = userService.createUser(userRequest);
+        var responseDTO = UserConverter.toUserResponseDTO(user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(responseDTO));
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/converter/UserConverter.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/converter/UserConverter.java
@@ -1,0 +1,15 @@
+package com.capston_design.fkiller.itoms.user_service.converter;
+
+import com.capston_design.fkiller.itoms.user_service.dto.UserResponse;
+import com.capston_design.fkiller.itoms.user_service.model.User;
+
+public class UserConverter {
+    public static UserResponse.UserCreateResponseDTO toUserResponseDTO(User user) {
+        return UserResponse.UserCreateResponseDTO.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .category(user.getCategory())
+                .createdAt(user.getCreatedAt().toLocalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/converter/UserConverter.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/converter/UserConverter.java
@@ -8,8 +8,8 @@ public class UserConverter {
         return UserResponse.UserCreateResponseDTO.builder()
                 .id(user.getId())
                 .name(user.getName())
-                .category(user.getCategory())
-                .createdAt(user.getCreatedAt().toLocalDate())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserRequest.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserRequest.java
@@ -1,0 +1,6 @@
+package com.capston_design.fkiller.itoms.user_service.dto;
+
+public record UserRequest (
+    String name,
+    String category
+){}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public class UserResponse {
     @Builder
@@ -15,7 +16,7 @@ public class UserResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserCreateResponseDTO{
-        private long id;
+        private UUID id;
         private String name;
         private UserCategory category;
 

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
@@ -1,0 +1,27 @@
+package com.capston_design.fkiller.itoms.user_service.dto;
+
+import com.capston_design.fkiller.itoms.user_service.model.enums.UserCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class UserResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserCreateResponseDTO{
+        private long id;
+        private String name;
+        private UserCategory category;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDate createdAt;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDate updatedAt;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/dto/UserResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class UserResponse {
     @Builder
@@ -20,8 +20,9 @@ public class UserResponse {
         private UserCategory category;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDate createdAt;
+        private LocalDateTime createdAt;
+
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDate updatedAt;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/model/User.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/model/User.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.UUID;
+
 
 @Entity
 @Table(name= "t_user")
@@ -18,7 +20,7 @@ import lombok.Setter;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private UUID id;
     private String name;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/model/User.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/model/User.java
@@ -1,0 +1,26 @@
+package com.capston_design.fkiller.itoms.user_service.model;
+
+import com.capston_design.fkiller.itoms.user_service.model.common.BaseEntity;
+import com.capston_design.fkiller.itoms.user_service.model.enums.UserCategory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+@Table(name= "t_user")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private UserCategory category;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/model/common/BaseEntity.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/model/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.capston_design.fkiller.itoms.user_service.model.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/model/enums/UserCategory.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/model/enums/UserCategory.java
@@ -1,6 +1,15 @@
 package com.capston_design.fkiller.itoms.user_service.model.enums;
 
+import java.util.Arrays;
+
 public enum UserCategory {
     INTERNAL,
-    OUTSOURCED
+    OUTSOURCED;
+
+    public static UserCategory from(String value) {
+        return Arrays.stream(values())
+                .filter(v -> v.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown category: " + value));
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/model/enums/UserCategory.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/model/enums/UserCategory.java
@@ -1,0 +1,6 @@
+package com.capston_design.fkiller.itoms.user_service.model.enums;
+
+public enum UserCategory {
+    INTERNAL,
+    OUTSOURCED
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/repository/UserRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.capston_design.fkiller.itoms.user_service.repository;
+
+import com.capston_design.fkiller.itoms.user_service.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/user_service/service/UserService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/user_service/service/UserService.java
@@ -1,0 +1,28 @@
+package com.capston_design.fkiller.itoms.user_service.service;
+
+import com.capston_design.fkiller.itoms.user_service.dto.UserRequest;
+import com.capston_design.fkiller.itoms.user_service.model.User;
+import com.capston_design.fkiller.itoms.user_service.model.enums.UserCategory;
+import com.capston_design.fkiller.itoms.user_service.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User createUser(UserRequest userRequest) {
+
+        User user = new User();
+
+        user.setName(userRequest.name());
+        user.setCategory(UserCategory.from(userRequest.category()));
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,12 +3,12 @@ spring:
     name: user-service
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/user_service
-    username: root
-    password: mysql
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: ${DDL_ENV}
     open-in-view: true
     show-sql: true
     properties:
@@ -18,4 +18,4 @@ spring:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui.html
+    path: ${SWAGGER_PATH}/swagger-ui.html

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: user-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/user_service
+    username: root
+    password: mysql
+  jpa:
+    hibernate:
+      ddl-auto: create
+    open-in-view: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: user-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: ${DDL_ENV}
+    open-in-view: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+
+springdoc:
+  swagger-ui:
+    path: ${SWAGGER_PATH}/swagger-ui.html

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.application.name=user-service
+# spring.application.name=user-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  # settings for profile
+  profiles:
+    active: local  # if you want to have the environment of the develop server, then it should be dev not local
+    include: secret
+  # settings for multipart data such as image
+
+  servlet:
+    multipart:
+      max-file-size: 10GB
+      max-request-size: 10GB


### PR DESCRIPTION
## 📝 PR 요약
User 생성 API

## 📌 관련 이슈
- Resolved: #1 

## 📂 변경 사항
- [x] Docker Compose로 MySQL 
  - [x] MySQL 8.3 이미지 정의
  - [x] 볼륨 설정 (./mysql 폴더)
- [x] User 생성 기능 구현
  - [x] UserService에  User 생성 로직 구현
  - [x]  User 엔티티 정의
- [x] API 응답 통일 & 에러 헨들링
  - [x] 공통 ApiResponse로 응답 통일
  - [x] 예외 처리기(ExceptionAdvice) 구조 적용
  - [x] Converter 구성(IncidentConverter에 Entity → DTO 변환)

## ✅ PR 체크리스트
- [ ] UserEntity는 우선 id, 이름, 역할 이렇게만 둘게요
- [ ] 코드 구성은 service-desk와 동일합니다!

## 🤔 추가 논의 사항
user service를 만들어야지 전반적인 요청할 때 사용자 할당 같은 거를 할 수 있어서 만들었습니다.
통신하는거 이제 구현해야할 것 같습니다.
